### PR TITLE
Allow TCP connection shutdown to fail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ authors = ["EKR <ekr@rtfm.com>"]
 [features]
 
 [dependencies]
-mio = "0.6"
+mio = "0.6.12"
+mio-extras = "2.0.3"
 rustc-serialize = "0.3"
 log = "0"
 env_logger = "0"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,9 @@
 extern crate mio;
+extern crate mio_extras;
+
 use mio::*;
-use mio::channel::Receiver;
+use mio_extras::channel;
+use mio_extras::channel::Receiver;
 use mio::tcp::{TcpListener, TcpStream};
 use std::process::{Command, ExitStatus};
 use std::thread;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -31,8 +31,12 @@ impl Agent {
                agent: &Option<TestCaseAgent>,
                args: Vec<String>)
                -> Result<Agent, i32> {
-        let addr = "127.0.0.1:0".parse().unwrap();
-        let listener = TcpListener::bind(&addr).unwrap();
+        // IPv6 listener by default, IPv4 fallback.
+        let addr = "[::1]:0".parse().unwrap();
+        let listener = TcpListener::bind(&addr).or_else(|_| {
+          let addr = "127.0.0.1:0".parse().unwrap();
+          TcpListener::bind(&addr)
+        }).unwrap();
 
         // Start the subprocess.
         let mut command = Command::new(path.to_owned());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate clap;
 #[macro_use]
 extern crate log;
 extern crate mio;
+extern crate mio_extras;
 extern crate env_logger;
 extern crate rustc_serialize;
 use clap::{Arg, App};
@@ -26,7 +27,7 @@ const SERVER: Token = mio::Token(1);
 
 fn copy_data(poll: &Poll, from: &mut Agent, to: &mut Agent) {
     let mut buf: [u8; 16384] = [0; 16384];
-    let mut b = &mut buf[..];
+    let b = &mut buf[..];
     let rv = from.socket.read(b);
     let size = rv.unwrap_or_else(|e| {
         debug!("Error {} on {}", e, from.name);
@@ -225,7 +226,7 @@ fn run_test_case_inner(config: &TestConfig,
 }
 
 fn main() {
-    env_logger::init().expect("Could not init logging");
+    env_logger::init();
 
     let matches = App::new("TLS interop tests")
         .version("0.0")

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,12 @@ fn copy_data(poll: &Poll, from: &mut Agent, to: &mut Agent) {
     if size == 0 {
         debug!("End of file on {}", from.name);
         poll.deregister(&from.socket).expect("Could not deregister socket");
-        to.socket.shutdown(Shutdown::Write).expect("Shutdown failed");
+        match to.socket.shutdown(Shutdown::Write) {
+            Ok(()) => {}
+            Err(_) => {
+                debug!("Shutdown of write to {} failed", to.name);
+            }
+        }
         from.alive = false;
         return;
     }


### PR DESCRIPTION
This integrates Tim's changes from #2, which we have been using in CI for a while now.  Also, my half-close patch revealed that the code for shuffling data back and forth wasn't resilient against a connection closing at an inopportune moment.

Previously, both read and write closed more or less simultaneously.  Thus you would get a log like this:

```
DEBUG:tls_interop: Read 110 from client
DEBUG:tls_interop: Write succeeded
DEBUG:tls_interop: Poll
DEBUG:tls_interop: Read 24 from server
DEBUG:tls_interop: Write succeeded
DEBUG:tls_interop: Poll
DEBUG:tls_interop: End of file on server
DEBUG:tls_interop: Poll
DEBUG:tls_interop: End of file on client
```

But with half-close, the close alert from both sides goes out when closing.  Consequently, the alert is available on the side that is second to close.  The harness tries to close the connection when it is already closed and panics.

Now we get...

```
DEBUG:tls_interop: Read 110 from client
DEBUG:tls_interop: Write succeeded
DEBUG:tls_interop: Poll
DEBUG:tls_interop: Read 24 from server
DEBUG:tls_interop: Write succeeded
DEBUG:tls_interop: Poll
DEBUG:tls_interop: End of file on server
DEBUG:tls_interop: Poll
DEBUG:tls_interop: Read 24 from client
DEBUG:tls_interop: Write succeeded
DEBUG:tls_interop: Poll
DEBUG:tls_interop: End of file on client
DEBUG:tls_interop: Shutdown of write to server failed
```